### PR TITLE
Remove global body flex centering

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }


### PR DESCRIPTION
## Summary
- allow sections to manage their own centering via Tailwind by removing `display: flex` and `place-items: center` from `body`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c17d515c83308ab2c5015afd25b0