### PR TITLE
Remove duplicate index.css import

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,10 @@
 import './index.css';
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## Summary
- eliminate duplicate index.css import in React app entry point
- standardize imports in main entry point

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6890c1700ce08330868ce815dac265ee