### PR TITLE
Enhance section animations and interactive effects

### DIFF
--- a/src/chapters/GrowthSection.jsx
+++ b/src/chapters/GrowthSection.jsx
@@ -16,7 +16,13 @@ export default function GrowthSection() {
       </Motion.h2>
       <div className="max-w-3xl mx-auto space-y-16">
         {timeline.map(([month, text], i) => (
-          <Motion.div key={i} initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} transition={{ delay: i * 0.3 }}>
+          <Motion.div
+            key={i}
+            initial={{ x: -100, opacity: 0 }}
+            whileInView={{ x: 0, opacity: 1 }}
+            viewport={{ once: true }}
+            transition={{ type: 'spring', stiffness: 100, delay: i * 0.2 }}
+          >
             <h4 className="text-2xl font-semibold mb-2">{month}</h4>
             <p className="text-neutral-600 leading-relaxed">{text}</p>
           </Motion.div>

--- a/src/chapters/IntroSection.jsx
+++ b/src/chapters/IntroSection.jsx
@@ -2,17 +2,38 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 
+const container = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.3,
+    },
+  },
+};
+
+const fadeUp = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+const scaleIn = {
+  hidden: { opacity: 0, scale: 0.8 },
+  visible: { opacity: 1, scale: 1 },
+};
+
 export default function IntroSection() {
   return (
-    <section
+    <Motion.section
       id="intro"
       className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={container}
     >
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-6"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
+        variants={fadeUp}
         transition={{ duration: 0.8 }}
       >
         Jij bent de brug tussen AI en impact
@@ -22,21 +43,18 @@ export default function IntroSection() {
         src="/avatar_placeholder.png"
         alt="Cinematic Avatar"
         className="w-64 h-64 rounded-2xl shadow-lg mb-8 object-cover"
-        initial={{ scale: 0.8, opacity: 0 }}
-        whileInView={{ scale: 1, opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: 0.3, duration: 0.8 }}
+        variants={scaleIn}
+        transition={{ duration: 0.8 }}
       />
 
       <Motion.p
         className="text-lg md:text-xl text-neutral-600 max-w-2xl leading-relaxed"
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: 0.6, duration: 0.8 }}
+        variants={fadeUp}
+        transition={{ duration: 0.8 }}
       >
         Je combineert creativiteit met controle. Je schakelt tussen frontend elegantie en backend robuustheid, met AI als ultiem hulpmiddel.
       </Motion.p>
-    </section>
+    </Motion.section>
   );
 }
+

--- a/src/chapters/MissionSection.jsx
+++ b/src/chapters/MissionSection.jsx
@@ -1,17 +1,33 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 
+const container = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.3,
+    },
+  },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
 export default function MissionSection() {
   return (
-    <section
+    <Motion.section
       id="mission"
       className="min-h-screen flex flex-col items-center justify-center bg-white px-4 py-20 text-center"
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+      variants={container}
     >
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-6"
-        initial={{ opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
+        variants={item}
         transition={{ duration: 0.8 }}
       >
         Waarom deze rol ertoe doet
@@ -19,16 +35,14 @@ export default function MissionSection() {
 
       <Motion.p
         className="text-xl md:text-2xl text-neutral-800 font-light text-center max-w-3xl leading-relaxed"
-        initial={{ opacity: 0 }}
-        whileInView={{ opacity: 1 }}
-        viewport={{ once: true }}
-        transition={{ delay: 0.3, duration: 0.8 }}
+        variants={item}
+        transition={{ duration: 0.8 }}
       >
-        Onze AI-strategie heeft bruggenbouwers nodig. Jij maakt complexe technologie
-        begrijpelijk, schaalbaar en menselijk.
+        Onze AI-strategie heeft bruggenbouwers nodig. Jij maakt complexe technologie begrijpelijk, schaalbaar en menselijk.
       </Motion.p>
 
       {/* Parallax-achtergrondvisual volgt hier */}
-    </section>
+    </Motion.section>
   );
 }
+

--- a/src/chapters/ResponsibilitiesSection.jsx
+++ b/src/chapters/ResponsibilitiesSection.jsx
@@ -23,6 +23,8 @@ export default function ResponsibilitiesSection() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ delay: idx * 0.2 }}
+            whileHover={{ scale: 1.05 }}
+            whileTap={{ scale: 0.95 }}
           >
             <div className="h-12 w-12 bg-teal-100 rounded-full mb-4 flex items-center justify-center">
               {/* Icon placeholder */}

--- a/src/chapters/SuperpowersSection.jsx
+++ b/src/chapters/SuperpowersSection.jsx
@@ -18,7 +18,13 @@ export default function SuperpowersSection() {
           <Motion.div key={i} initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} transition={{ delay: i * 0.3 }}>
             <h3 className="text-lg font-medium">{skill.name}</h3>
             <div className="w-full bg-neutral-100 rounded-full h-2 mt-2 mb-1">
-              <div className="bg-gradient-to-r from-sky-400 to-blue-600 h-2 rounded-full" style={{ width: `${skill.level}%` }} />
+              <Motion.div
+                className="bg-gradient-to-r from-sky-400 to-blue-600 h-2 rounded-full shadow-[0_0_10px]"
+                initial={{ width: 0 }}
+                whileInView={{ width: `${skill.level}%` }}
+                viewport={{ once: true }}
+                transition={{ duration: 1 }}
+              />
             </div>
             <span className="text-sm text-neutral-500">{skill.level}%</span>
           </Motion.div>


### PR DESCRIPTION
## Summary
- stagger intro and mission content with container `staggerChildren`
- animate growth timeline with sweeping spring transitions
- scale responsibility cards on hover/tap and add animated superpower bars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c3c490048330ba190684f21d895e