### PR TITLE
fix: use fa6 icon import in ShareProfile

### DIFF
--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
-import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa';
+import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa6';
 
 export default function ShareProfile() {
   return (


### PR DESCRIPTION
## Summary
- use Font Awesome 6 module from `react-icons/fa6` in ShareProfile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_b_6890c72696748330bfec37d8c77f3252