### PR TITLE
Smooth scroll to intro section

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -1,11 +1,8 @@
-import { useRef } from 'react';
 import { motion as Motion } from 'framer-motion';
 
 export default function Landing() {
-  const sectionRef = useRef(null);
-
   const handleClick = () => {
-    sectionRef.current?.scrollIntoView({ behavior: 'smooth' });
+    document.getElementById('intro')?.scrollIntoView({ behavior: 'smooth' });
   };
 
   return (
@@ -87,7 +84,6 @@ export default function Landing() {
         Explore my dream job
       </Motion.button>
 
-      <div ref={sectionRef} className="w-full" />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Smooth scroll to intro section on landing-page button click
- Remove unused ref and trailing div

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c72bbafc833092bdd4f57e75aa4e