### PR TITLE
Add explicit button types to non-form buttons

### DIFF
--- a/src/chapters/FinalCTASection.jsx
+++ b/src/chapters/FinalCTASection.jsx
@@ -16,10 +16,10 @@ export default function FinalCTASection() {
         ))}
       </Motion.ul>
       <Motion.div initial={{ opacity: 0 }} whileInView={{ opacity: 1 }} transition={{ delay: 0.5 }}>
-        <button className="mx-2 px-6 py-3 bg-black text-white rounded-full hover:bg-neutral-800 transition">
+        <button type="button" className="mx-2 px-6 py-3 bg-black text-white rounded-full hover:bg-neutral-800 transition">
           Terug naar overzicht
         </button>
-        <button className="mx-2 px-6 py-3 border border-neutral-300 bg-white text-neutral-700 rounded-full hover:bg-neutral-100 transition">
+        <button type="button" className="mx-2 px-6 py-3 border border-neutral-300 bg-white text-neutral-700 rounded-full hover:bg-neutral-100 transition">
           Deel profiel
         </button>
       </Motion.div>

--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -16,6 +16,7 @@ export default function ShareProfile() {
       >
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}
@@ -26,6 +27,7 @@ export default function ShareProfile() {
         </div>
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}
@@ -36,6 +38,7 @@ export default function ShareProfile() {
         </div>
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
## Summary
- add `type="button"` to CTA section navigation buttons
- add `type="button"` to share profile buttons

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_6890c7309180833093a21b112992db2a