### PR TITLE
feat: add share actions with accessible buttons

### DIFF
--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -3,8 +3,38 @@ import { motion as Motion } from 'framer-motion';
 import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa';
 
 export default function ShareProfile() {
+  const handleLinkedInShare = () => {
+    const url = encodeURIComponent(window.location.href);
+    const shareUrl = `https://www.linkedin.com/shareArticle?mini=true&url=${url}`;
+    window.open(shareUrl, '_blank', 'noopener');
+  };
+
+  const handleWhatsAppShare = () => {
+    const text = encodeURIComponent(`Check out my profile: ${window.location.href}`);
+    const shareUrl = `https://wa.me/?text=${text}`;
+    window.open(shareUrl, '_blank', 'noopener');
+  };
+
+  const handleDownload = async () => {
+    try {
+      const html2canvas = (await import('https://esm.sh/html2canvas')).default;
+      const node = document.getElementById('share');
+      if (!node) return;
+      const canvas = await html2canvas(node);
+      const link = document.createElement('a');
+      link.download = 'profile.png';
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    } catch (error) {
+      console.error('Failed to download image', error);
+    }
+  };
+
   return (
-    <section id="share" className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center">
+    <section
+      id="share"
+      className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center"
+    >
       <Motion.h2 className="text-3xl md:text-4xl font-semibold text-center mb-6">
         Deel je profiel met de wereld
       </Motion.h2>
@@ -16,9 +46,12 @@ export default function ShareProfile() {
       >
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}
+            onClick={handleLinkedInShare}
+            aria-label="Deel op LinkedIn"
           >
             <FaLinkedin />
             LinkedIn
@@ -26,9 +59,12 @@ export default function ShareProfile() {
         </div>
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}
+            onClick={handleWhatsAppShare}
+            aria-label="Deel via WhatsApp"
           >
             <FaWhatsapp />
             WhatsApp
@@ -36,9 +72,12 @@ export default function ShareProfile() {
         </div>
         <div className="p-[2px] rounded-full bg-gradient-to-r from-teal-400 via-blue-500 to-purple-600">
           <Motion.button
+            type="button"
             className="flex items-center gap-2 px-4 py-2 bg-white rounded-full text-black"
             whileHover={{ scale: 1.1, rotate: 1 }}
             whileTap={{ scale: 0.95 }}
+            onClick={handleDownload}
+            aria-label="Download profiel als PNG"
           >
             <FaDownload />
             Download PNG


### PR DESCRIPTION
## Summary
- add LinkedIn and WhatsApp share handlers
- generate downloadable PNG of the profile section
- improve accessibility with aria labels

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c72ddd9c833091ff4e8ad64c7624