### PR TITLE
refactor: centralize motion variants

### DIFF
--- a/src/chapters/IntroSection.jsx
+++ b/src/chapters/IntroSection.jsx
@@ -1,25 +1,7 @@
 // src/chapters/IntroSection.jsx
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
-
-const container = {
-  hidden: {},
-  visible: {
-    transition: {
-      staggerChildren: 0.3,
-    },
-  },
-};
-
-const fadeUp = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0 },
-};
-
-const scaleIn = {
-  hidden: { opacity: 0, scale: 0.8 },
-  visible: { opacity: 1, scale: 1 },
-};
+import { container, fadeUp, scaleIn } from '../utils/motionVariants';
 
 export default function IntroSection() {
   return (

--- a/src/chapters/MissionSection.jsx
+++ b/src/chapters/MissionSection.jsx
@@ -1,19 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
-
-const container = {
-  hidden: {},
-  visible: {
-    transition: {
-      staggerChildren: 0.3,
-    },
-  },
-};
-
-const item = {
-  hidden: { opacity: 0, y: 20 },
-  visible: { opacity: 1, y: 0 },
-};
+import { container, item } from '../utils/motionVariants';
 
 export default function MissionSection() {
   return (

--- a/src/utils/motionVariants.js
+++ b/src/utils/motionVariants.js
@@ -1,0 +1,20 @@
+export const container = {
+  hidden: {},
+  visible: {
+    transition: {
+      staggerChildren: 0.3,
+    },
+  },
+};
+
+export const fadeUp = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
+export const scaleIn = {
+  hidden: { opacity: 0, scale: 0.8 },
+  visible: { opacity: 1, scale: 1 },
+};
+
+export const item = fadeUp;


### PR DESCRIPTION
## Summary
- add shared `motionVariants` utility with container, fadeUp, scaleIn, and item animations
- refactor chapter components to import shared variants instead of defining inline

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c732056c8330afea5b2a6c777bd3