### PR TITLE
refactor: centralize section wrapper into component

### DIFF
--- a/src/chapters/FinalCTASection.jsx
+++ b/src/chapters/FinalCTASection.jsx
@@ -1,14 +1,23 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function FinalCTASection() {
   return (
-    <section id="cta" className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center">
+    <WrappedSection id="cta" bgGradient="bg-gray-50">
       <Motion.h2 className="text-4xl md:text-5xl font-semibold text-center mb-6">
         Deze functie past bij jou…
       </Motion.h2>
-      <Motion.ul className="space-y-4 text-neutral-600 mb-10 text-center" initial={{ opacity: 0 }} whileInView={{ opacity: 1 }}>
-        {['Als je energie krijgt van AI als hulpmiddel','Als je ownership voelt voor alles wat je bouwt','Als je met visie én scherpte wilt bijdragen'].map((item, idx) => (
+      <Motion.ul
+        className="space-y-4 text-neutral-600 mb-10 text-center"
+        initial={{ opacity: 0 }}
+        whileInView={{ opacity: 1 }}
+      >
+        {[
+          'Als je energie krijgt van AI als hulpmiddel',
+          'Als je ownership voelt voor alles wat je bouwt',
+          'Als je met visie én scherpte wilt bijdragen',
+        ].map((item, idx) => (
           <li key={idx} className="flex items-center justify-center">
             <span className="mr-2 text-teal-500">✨</span>
             {item}
@@ -23,6 +32,7 @@ export default function FinalCTASection() {
           Deel profiel
         </button>
       </Motion.div>
-    </section>
+    </WrappedSection>
   );
 }
+

--- a/src/chapters/GrowthSection.jsx
+++ b/src/chapters/GrowthSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function GrowthSection() {
   const timeline = [
@@ -10,7 +11,7 @@ export default function GrowthSection() {
   ];
 
   return (
-    <section id="growth" className="min-h-screen bg-gray-50 px-4 py-20 flex flex-col items-center justify-center text-center">
+    <WrappedSection id="growth" bgGradient="bg-gray-50">
       <Motion.h2 className="text-4xl md:text-5xl font-semibold text-center mb-8">
         De impact die jij maakt
       </Motion.h2>
@@ -28,6 +29,7 @@ export default function GrowthSection() {
           </Motion.div>
         ))}
       </div>
-    </section>
+    </WrappedSection>
   );
 }
+

--- a/src/chapters/IntroSection.jsx
+++ b/src/chapters/IntroSection.jsx
@@ -1,6 +1,7 @@
 // src/chapters/IntroSection.jsx
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 const container = {
   hidden: {},
@@ -23,14 +24,7 @@ const scaleIn = {
 
 export default function IntroSection() {
   return (
-    <Motion.section
-      id="intro"
-      className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center"
-      initial="hidden"
-      whileInView="visible"
-      viewport={{ once: true }}
-      variants={container}
-    >
+    <WrappedSection id="intro" bgGradient="bg-gray-50" variants={container}>
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-6"
         variants={fadeUp}
@@ -54,7 +48,7 @@ export default function IntroSection() {
       >
         Je combineert creativiteit met controle. Je schakelt tussen frontend elegantie en backend robuustheid, met AI als ultiem hulpmiddel.
       </Motion.p>
-    </Motion.section>
+    </WrappedSection>
   );
 }
 

--- a/src/chapters/MissionSection.jsx
+++ b/src/chapters/MissionSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 const container = {
   hidden: {},
@@ -17,14 +18,7 @@ const item = {
 
 export default function MissionSection() {
   return (
-    <Motion.section
-      id="mission"
-      className="min-h-screen flex flex-col items-center justify-center bg-white px-4 py-20 text-center"
-      initial="hidden"
-      whileInView="visible"
-      viewport={{ once: true }}
-      variants={container}
-    >
+    <WrappedSection id="mission" bgGradient="bg-white" variants={container}>
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-6"
         variants={item}
@@ -42,7 +36,7 @@ export default function MissionSection() {
       </Motion.p>
 
       {/* Parallax-achtergrondvisual volgt hier */}
-    </Motion.section>
+    </WrappedSection>
   );
 }
 

--- a/src/chapters/ResponsibilitiesSection.jsx
+++ b/src/chapters/ResponsibilitiesSection.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function ResponsibilitiesSection() {
   return (
-    <section id="responsibilities" className="min-h-screen bg-gray-50 px-4 py-20 flex flex-col items-center justify-center text-center">
+    <WrappedSection id="responsibilities" bgGradient="bg-gray-50">
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-8"
         initial={{ opacity: 0, y: 20 }}
@@ -35,6 +36,7 @@ export default function ResponsibilitiesSection() {
           </Motion.div>
         ))}
       </div>
-    </section>
+    </WrappedSection>
   );
 }
+

--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa';
+import WrappedSection from '../components/WrappedSection';
 
 export default function ShareProfile() {
   return (
-    <section id="share" className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center">
+    <WrappedSection id="share" bgGradient="bg-gray-50">
       <Motion.h2 className="text-3xl md:text-4xl font-semibold text-center mb-6">
         Deel je profiel met de wereld
       </Motion.h2>
@@ -48,6 +49,7 @@ export default function ShareProfile() {
       <p className="mt-6 text-lg font-medium bg-gradient-to-r from-teal-500 via-blue-500 to-purple-600 bg-clip-text text-transparent animate-pulse">
         Laat zien dat jij de AI-held bent!
       </p>
-    </section>
+    </WrappedSection>
   );
 }
+

--- a/src/components/WrappedSection.jsx
+++ b/src/components/WrappedSection.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion as Motion } from 'framer-motion';
+
+export default function WrappedSection({
+  id,
+  bgGradient = '',
+  initial = 'hidden',
+  whileInView = 'visible',
+  variants,
+  children,
+}) {
+  return (
+    <Motion.section
+      id={id}
+      className={`min-h-screen flex flex-col items-center justify-center px-4 py-20 text-center ${bgGradient}`}
+      initial={initial}
+      whileInView={whileInView}
+      viewport={{ once: true }}
+      variants={variants}
+    >
+      {children}
+    </Motion.section>
+  );
+}


### PR DESCRIPTION
## Summary
- add `WrappedSection` component to share layout, gradient, and viewport logic
- use `WrappedSection` across chapter sections to remove repeated markup

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_b_6890c73056a883309cfb1c034b6d76da