### PR TITLE
chore: set up vitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,11 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+# Running Tests
+
+Run the test suite with:
+
+```bash
+npm test
+```
 # reveal-webapp

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -28,6 +29,9 @@
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.0.0",
+    "jsdom": "^22.0.0"
   }
 }

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import { describe, it, beforeAll } from 'vitest';
+import App from '../App';
+
+beforeAll(() => {
+  globalThis.IntersectionObserver = class {
+    constructor() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('App', () => {
+  it('renders without crashing', () => {
+    render(<App />);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
 })


### PR DESCRIPTION
## Summary
- configure Vitest in Vite config with jsdom environment
- add React Testing Library and example App test
- document how to run tests

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6890c730d7948330bd0eb52f8e6870f6