### PR TITLE
feat: add html2canvas dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "framer-motion": "^12.23.12",
+    "html2canvas": "^1.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.0.1"
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@tailwindcss/postcss": "^4.1.11",
+    "@testing-library/react": "^14.0.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
@@ -27,11 +29,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "jsdom": "^22.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
     "vite": "^7.0.4",
-    "vitest": "^1.6.0",
-    "@testing-library/react": "^14.0.0",
-    "jsdom": "^22.0.0"
+    "vitest": "^1.6.0"
   }
 }

--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa6';
+import html2canvas from 'html2canvas';
 
 export default function ShareProfile() {
   const handleLinkedInShare = () => {
@@ -17,7 +18,6 @@ export default function ShareProfile() {
 
   const handleDownload = async () => {
     try {
-      const html2canvas = (await import('https://esm.sh/html2canvas')).default;
       const node = document.getElementById('share');
       if (!node) return;
       const canvas = await html2canvas(node);


### PR DESCRIPTION
## Summary
- add html2canvas as dependency
- use static html2canvas import for profile screenshot download

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_b_6890ca1fc4c4833098401e4d8b15ea38