### PR TITLE
refactor: centralize section layout with WrappedSection component

### DIFF
--- a/src/chapters/FinalCTASection.jsx
+++ b/src/chapters/FinalCTASection.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function FinalCTASection() {
   return (
-    <section id="cta" className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center">
+    <WrappedSection id="cta" bgGradient="bg-gray-50">
       <Motion.h2 className="text-4xl md:text-5xl font-semibold text-center mb-6">
         Deze functie past bij jou…
       </Motion.h2>
@@ -23,6 +24,6 @@ export default function FinalCTASection() {
           Deel profiel
         </button>
       </Motion.div>
-    </section>
+    </WrappedSection>
   );
 }

--- a/src/chapters/GrowthSection.jsx
+++ b/src/chapters/GrowthSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function GrowthSection() {
   const timeline = [
@@ -10,7 +11,7 @@ export default function GrowthSection() {
   ];
 
   return (
-    <section id="growth" className="min-h-screen bg-gray-50 px-4 py-20 flex flex-col items-center justify-center text-center">
+    <WrappedSection id="growth" bgGradient="bg-gray-50">
       <Motion.h2 className="text-4xl md:text-5xl font-semibold text-center mb-8">
         De impact die jij maakt
       </Motion.h2>
@@ -28,6 +29,6 @@ export default function GrowthSection() {
           </Motion.div>
         ))}
       </div>
-    </section>
+    </WrappedSection>
   );
 }

--- a/src/chapters/IntroSection.jsx
+++ b/src/chapters/IntroSection.jsx
@@ -2,15 +2,15 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { container, fadeUp, scaleIn } from '../utils/motionVariants';
+import WrappedSection from '../components/WrappedSection';
 
 export default function IntroSection() {
   return (
-    <Motion.section
+    <WrappedSection
       id="intro"
-      className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center"
+      bgGradient="bg-gray-50"
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: true }}
       variants={container}
     >
       <Motion.h2
@@ -36,7 +36,7 @@ export default function IntroSection() {
       >
         Je combineert creativiteit met controle. Je schakelt tussen frontend elegantie en backend robuustheid, met AI als ultiem hulpmiddel.
       </Motion.p>
-    </Motion.section>
+    </WrappedSection>
   );
 }
 

--- a/src/chapters/MissionSection.jsx
+++ b/src/chapters/MissionSection.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { container, item } from '../utils/motionVariants';
+import WrappedSection from '../components/WrappedSection';
 
 export default function MissionSection() {
   return (
-    <Motion.section
+    <WrappedSection
       id="mission"
-      className="min-h-screen flex flex-col items-center justify-center bg-white px-4 py-20 text-center"
+      bgGradient="bg-white"
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: true }}
       variants={container}
     >
       <Motion.h2
@@ -29,7 +29,7 @@ export default function MissionSection() {
       </Motion.p>
 
       {/* Parallax-achtergrondvisual volgt hier */}
-    </Motion.section>
+    </WrappedSection>
   );
 }
 

--- a/src/chapters/ResponsibilitiesSection.jsx
+++ b/src/chapters/ResponsibilitiesSection.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import WrappedSection from '../components/WrappedSection';
 
 export default function ResponsibilitiesSection() {
   return (
-    <section id="responsibilities" className="min-h-screen bg-gray-50 px-4 py-20 flex flex-col items-center justify-center text-center">
+    <WrappedSection id="responsibilities" bgGradient="bg-gray-50">
       <Motion.h2
         className="text-4xl md:text-5xl font-semibold text-center mb-8"
         initial={{ opacity: 0, y: 20 }}
@@ -35,6 +36,6 @@ export default function ResponsibilitiesSection() {
           </Motion.div>
         ))}
       </div>
-    </section>
+    </WrappedSection>
   );
 }

--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa6';
+import WrappedSection from '../components/WrappedSection';
 
 export default function ShareProfile() {
   const handleLinkedInShare = () => {
@@ -31,9 +32,9 @@ export default function ShareProfile() {
   };
 
   return (
-    <section
+    <WrappedSection
       id="share"
-      className="min-h-screen flex flex-col items-center justify-center bg-gray-50 px-4 py-20 text-center"
+      bgGradient="bg-gray-50"
     >
       <Motion.h2 className="text-3xl md:text-4xl font-semibold text-center mb-6">
         Deel je profiel met de wereld
@@ -87,6 +88,6 @@ export default function ShareProfile() {
       <p className="mt-6 text-lg font-medium bg-gradient-to-r from-teal-500 via-blue-500 to-purple-600 bg-clip-text text-transparent animate-pulse">
         Laat zien dat jij de AI-held bent!
       </p>
-    </section>
+    </WrappedSection>
   );
 }

--- a/src/components/WrappedSection.jsx
+++ b/src/components/WrappedSection.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { motion as Motion } from 'framer-motion';
+
+export default function WrappedSection({ id, bgGradient = '', children, viewport, ...rest }) {
+  return (
+    <Motion.section
+      id={id}
+      className={`min-h-screen flex flex-col items-center justify-center px-4 py-20 text-center ${bgGradient}`}
+      viewport={{ once: true, ...viewport }}
+      {...rest}
+    >
+      {children}
+    </Motion.section>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `WrappedSection` component for shared section styling and viewport settings
- refactor Intro, Mission, Responsibilities, Growth, Final CTA, and Share Profile chapters to use `WrappedSection`

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_6890ca1f8f988330b83230f70673abd8