### PR TITLE
chore: simplify vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,7 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  test: {
-    environment: 'jsdom'
-  }
 })


### PR DESCRIPTION
## Summary
- import `defineConfig` from Vite instead of Vitest
- drop unused Vitest test block

## Testing
- `npm install --legacy-peer-deps --registry=https://registry.npmjs.org` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@babel%2fruntime)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6890cade33388330b862f834905b22de