### PR TITLE
feat: add modern layout and landing styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,16 +14,14 @@ export default function App() {
   return (
     <div className="App overflow-x-hidden">
       <ProgressNav />
-      <div className="container mx-auto px-4 text-center">
-        <Landing />
-        <IntroSection />
-        <MissionSection />
-        <ResponsibilitiesSection />
-        <SuperpowersSection />
-        <GrowthSection />
-        <FinalCTASection />
-        <ShareProfile />
-      </div>
+      <Landing />
+      <IntroSection />
+      <MissionSection />
+      <ResponsibilitiesSection />
+      <SuperpowersSection />
+      <GrowthSection />
+      <FinalCTASection />
+      <ShareProfile />
     </div>
   );
 }

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -1,89 +1,38 @@
 import { motion as Motion } from 'framer-motion';
+import Layout from './Layout';
 
 export default function Landing() {
   const handleClick = () => {
     document.getElementById('intro')?.scrollIntoView({ behavior: 'smooth' });
   };
 
+  const motionProps = {
+    initial: { opacity: 0, y: 30 },
+    whileInView: { opacity: 1, y: 0 },
+    transition: { duration: 0.6, ease: 'easeOut' },
+    viewport: { once: true },
+  };
+
   return (
-    <section
-      className="relative min-h-screen flex flex-col items-center justify-center bg-black px-4 text-center overflow-hidden"
-      id="landing"
-    >
-      <Motion.div
-        className="pointer-events-none absolute -top-20 -left-20 w-72 h-72 bg-gradient-to-r from-lime-400 via-fuchsia-500 to-purple-600 rounded-full blur-3xl opacity-30 -z-10"
-        animate={{ rotate: 360 }}
-        transition={{ repeat: Infinity, duration: 20, ease: 'linear' }}
-      />
-      <Motion.div
-        className="pointer-events-none absolute -bottom-20 -right-20 w-72 h-72 bg-gradient-to-r from-purple-600 via-fuchsia-500 to-lime-400 rounded-full blur-3xl opacity-30 -z-10"
-        animate={{ rotate: -360 }}
-        transition={{ repeat: Infinity, duration: 25, ease: 'linear' }}
-      />
-
-      <Motion.h1
-        className="text-5xl md:text-7xl font-semibold tracking-tight mb-6 text-white"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{
-          opacity: 1,
-          y: 0,
-          rotate: [0, 2, -2, 0],
-          color: ['#fff', '#0f0', '#0ff', '#fff'],
-        }}
-        transition={{
-          duration: 0.8,
-          rotate: { repeat: Infinity, duration: 10 },
-          color: { repeat: Infinity, duration: 10 },
-        }}
-      >
-        Full Stack AI Developer
-      </Motion.h1>
-
-      <Motion.p
-        className="text-lg md:text-xl font-light mb-2 text-white"
-        initial={{ opacity: 0 }}
-        animate={{
-          opacity: 1,
-          rotate: [0, 2, -2, 0],
-          color: ['#fff', '#0f0', '#0ff', '#fff'],
-        }}
-        transition={{
-          delay: 0.5,
-          duration: 0.8,
-          rotate: { repeat: Infinity, duration: 10 },
-          color: { repeat: Infinity, duration: 10 },
-        }}
-      >
-        De sleutelrol in onze AI-transformatie.
-      </Motion.p>
-
-      <Motion.p
-        className="text-lg md:text-xl font-light mb-10 text-white"
-        initial={{ opacity: 0 }}
-        animate={{
-          opacity: 1,
-          rotate: [0, 2, -2, 0],
-          color: ['#fff', '#0f0', '#0ff', '#fff'],
-        }}
-        transition={{
-          delay: 1,
-          duration: 0.8,
-          rotate: { repeat: Infinity, duration: 10 },
-          color: { repeat: Infinity, duration: 10 },
-        }}
-      >
-        Jouw 2024 Wrapped job journey start hier
-      </Motion.p>
-
-      <Motion.button
-        onClick={handleClick}
-        className="px-8 py-4 bg-gradient-to-r from-lime-400 via-fuchsia-500 to-purple-600 text-white rounded-full shadow-lg focus:outline-none focus:ring-2 focus:ring-lime-400 transition-transform duration-300"
-        whileHover={{ scale: 1.1, rotate: 2 }}
-        whileTap={{ scale: 0.95 }}
-      >
-        Explore my dream job
-      </Motion.button>
-
-    </section>
+    <Layout>
+      <section className="text-center" id="landing">
+        <Motion.h1 className="headline text-gradient" {...motionProps}>
+          Full Stack AI Developer
+        </Motion.h1>
+        <Motion.p className="subheader" {...motionProps}>
+          De sleutelrol in onze AI-transformatie.
+        </Motion.p>
+        <Motion.p className="body-text" {...motionProps}>
+          Jouw 2024 Wrapped job journey start hier
+        </Motion.p>
+        <Motion.button
+          onClick={handleClick}
+          className="btn btn-primary mt-8"
+          {...motionProps}
+        >
+          Explore my dream job
+        </Motion.button>
+      </section>
+    </Layout>
   );
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Layout({ children }) {
+  return <div className="layout">{children}</div>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,33 @@
 
 @layer base {
   body {
-    @apply m-0 min-h-screen font-sans text-white bg-gradient-diagonal from-midnight via-purple to-fuchsia;
+    @apply m-0 min-h-screen font-sans bg-gradient-to-b from-white via-slate-50 to-slate-100 text-neutral-700;
   }
 }
 
+@layer components {
+  .layout {
+    @apply max-w-4xl mx-auto px-6 py-24 space-y-12;
+  }
+  .headline {
+    @apply font-bold text-5xl md:text-6xl tracking-tight text-neutral-900;
+  }
+  .subheader {
+    @apply text-xl text-neutral-600;
+  }
+  .body-text {
+    @apply text-base text-neutral-700 leading-relaxed;
+  }
+  .text-gradient {
+    @apply bg-clip-text text-transparent bg-gradient-to-r from-lime-400 via-sky-400 to-violet-500;
+  }
+  .btn {
+    @apply rounded-full px-6 py-3 hover:scale-105 transition;
+  }
+  .btn-primary {
+    @apply text-white bg-sky-500;
+  }
+  .btn-outline {
+    @apply bg-white text-black ring-2 ring-black;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable layout and typography utilities with soft gradient background
- restyle landing page with gradient headlines, motion fade and accent button
- streamline app structure to use per-section layout wrappers

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_6890cb7bfba88330953bbcdcbcf51e6b