### PR TITLE
Add interactive scroll navigation

### DIFF
--- a/src/chapters/FinalCTASection.jsx
+++ b/src/chapters/FinalCTASection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import ScrollButton from '../components/ScrollButton';
 
 export default function FinalCTASection() {
   return (
@@ -23,6 +24,7 @@ export default function FinalCTASection() {
           Deel profiel
         </button>
       </Motion.div>
+      <ScrollButton targetId="share" />
     </section>
   );
 }

--- a/src/chapters/GrowthSection.jsx
+++ b/src/chapters/GrowthSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import ScrollButton from '../components/ScrollButton';
 
 export default function GrowthSection() {
   const timeline = [
@@ -28,6 +29,7 @@ export default function GrowthSection() {
           </Motion.div>
         ))}
       </div>
+      <ScrollButton targetId="cta" />
     </section>
   );
 }

--- a/src/chapters/IntroSection.jsx
+++ b/src/chapters/IntroSection.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { container, fadeUp, scaleIn } from '../utils/motionVariants';
+import ScrollButton from '../components/ScrollButton';
 
 export default function IntroSection() {
   return (
@@ -36,6 +37,7 @@ export default function IntroSection() {
       >
         Je combineert creativiteit met controle. Je schakelt tussen frontend elegantie en backend robuustheid, met AI als ultiem hulpmiddel.
       </Motion.p>
+      <ScrollButton targetId="mission" />
     </Motion.section>
   );
 }

--- a/src/chapters/MissionSection.jsx
+++ b/src/chapters/MissionSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { container, item } from '../utils/motionVariants';
+import ScrollButton from '../components/ScrollButton';
 
 export default function MissionSection() {
   return (
@@ -27,6 +28,7 @@ export default function MissionSection() {
       >
         Onze AI-strategie heeft bruggenbouwers nodig. Jij maakt complexe technologie begrijpelijk, schaalbaar en menselijk.
       </Motion.p>
+      <ScrollButton targetId="responsibilities" />
 
       {/* Parallax-achtergrondvisual volgt hier */}
     </Motion.section>

--- a/src/chapters/ResponsibilitiesSection.jsx
+++ b/src/chapters/ResponsibilitiesSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import ScrollButton from '../components/ScrollButton';
 
 export default function ResponsibilitiesSection() {
   return (
@@ -35,6 +36,7 @@ export default function ResponsibilitiesSection() {
           </Motion.div>
         ))}
       </div>
+      <ScrollButton targetId="superpowers" />
     </section>
   );
 }

--- a/src/chapters/ShareProfile.jsx
+++ b/src/chapters/ShareProfile.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
 import { FaLinkedin, FaWhatsapp, FaDownload } from 'react-icons/fa6';
+import ScrollButton from '../components/ScrollButton';
 import html2canvas from 'html2canvas';
 
 export default function ShareProfile() {
@@ -87,6 +88,9 @@ export default function ShareProfile() {
       <p className="mt-6 text-lg font-medium bg-gradient-to-r from-teal-500 via-blue-500 to-purple-600 bg-clip-text text-transparent animate-pulse">
         Laat zien dat jij de AI-held bent!
       </p>
+      <ScrollButton targetId="landing" direction="up">
+        Terug naar begin
+      </ScrollButton>
     </section>
   );
 }

--- a/src/chapters/SuperpowersSection.jsx
+++ b/src/chapters/SuperpowersSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { motion as Motion } from 'framer-motion';
+import ScrollButton from '../components/ScrollButton';
 
 export default function SuperpowersSection() {
   const skills = [
@@ -30,6 +31,7 @@ export default function SuperpowersSection() {
           </Motion.div>
         ))}
       </div>
+      <ScrollButton targetId="growth" />
     </section>
   );
 }

--- a/src/components/ScrollButton.jsx
+++ b/src/components/ScrollButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { motion as Motion } from 'framer-motion';
+import { FaArrowDown, FaArrowUp } from 'react-icons/fa6';
+
+export default function ScrollButton({ targetId, direction = 'down', children = 'Volgende' }) {
+  const handleClick = () => {
+    document.getElementById(targetId)?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const Icon = direction === 'up' ? FaArrowUp : FaArrowDown;
+
+  return (
+    <Motion.button
+      type="button"
+      onClick={handleClick}
+      className="mt-10 flex items-center gap-2 text-teal-600 hover:text-teal-800 mx-auto"
+      animate={{ y: [0, -5, 0] }}
+      transition={{ repeat: Infinity, duration: 1.5 }}
+    >
+      {children}
+      <Icon />
+    </Motion.button>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `ScrollButton` with bouncing arrow
- guide users through sections and back to start for more interactive journey

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_6891e819add08330abd7a9c3d4eac010